### PR TITLE
Fixed columns jumping around when expending rows.

### DIFF
--- a/projects/wouter-willems/data-table/src/lib/data-table/data-table.component.html
+++ b/projects/wouter-willems/data-table/src/lib/data-table/data-table.component.html
@@ -141,7 +141,7 @@
 				</td>
 			</tr>
 			<tr *ngIf="getExpandedTplFn?.()?.index === i">
-				<td colspan="999">
+				<td [attr.colspan]="getTotalAmountOfCols()">
 					<ng-container [ngTemplateOutlet]="getExpandedTplFn()?.tpl" [ngTemplateOutletContext]="{row: row}"></ng-container>
 				</td>
 			</tr>

--- a/projects/wouter-willems/data-table/src/lib/data-table/data-table.component.ts
+++ b/projects/wouter-willems/data-table/src/lib/data-table/data-table.component.ts
@@ -857,4 +857,8 @@ export class DataTableComponent implements OnChanges, OnInit, OnDestroy {
 		this.closeActionMenu();
 		this.closeFilters();
 	}
+
+	public getTotalAmountOfCols(): number {
+		return [...this.elRef.nativeElement.querySelectorAll('thead td')].length;
+	}
 }


### PR DESCRIPTION
The issue occurs because setting the `colspan` to theoretically high number to make sure it is the entire width of the table, like 999, does not correctly work with `table-layout: fixed;`

This issue is also discussed in the following stack-overflow thread: https://stackoverflow.com/questions/398734/colspan-all-columns

https://github.com/user-attachments/assets/472aa2f4-b5ae-4f45-b502-48a32a609e2a




